### PR TITLE
fixed onboarding flow for users authenticated with social providers

### DIFF
--- a/backend/controllers/userController.ts
+++ b/backend/controllers/userController.ts
@@ -62,6 +62,30 @@ export const provideAdditionalUserInfo = async (req: any, res: any) => {
   } catch (error: any) {}
 }
 
+// Get the groupID of a specific user
+export const getUserGroup = async (req: Request, res: Response) => {
+  try {
+    const { userID } = req.params;
+
+    const user = await User.findById(userID).select('groupID');
+    
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    return res.status(200).json({ 
+      groupID: user.groupID 
+    });
+    
+  } catch (error: any) {
+    console.error('Error fetching user group:', error);
+    return res.status(500).json({ 
+      message: 'Failed to fetch user group',
+      error: error.message 
+    });
+  }
+};
+
 export const getUser = async (req: TypedRequest<any, UserParams>, res: Response): Promise<void> => {
   try {
     const user = await User.findById(req.params.userID);

--- a/backend/routes/userRoutes.ts
+++ b/backend/routes/userRoutes.ts
@@ -1,10 +1,10 @@
 import express, { Router } from 'express';
-import { getUser, provideAdditionalUserInfo, getUserIdByClerkId } from '../controllers/userController';
+import { getUser, provideAdditionalUserInfo, getUserIdByClerkId, getUserGroup } from '../controllers/userController';
 import { createGroup, joinGroup } from '../controllers/groupController';
 
 const router: Router = express.Router();
 
-router.get('/:userID', getUser);  
+router.get('/:userID/group', getUserGroup);  
 router.patch('/:userID/onboarding', provideAdditionalUserInfo);
 router.get('/clerk/:clerkID', getUserIdByClerkId);
 router.post('/:userID/createGroup', createGroup);

--- a/frontend/app/(protected)/setup/congrats.tsx
+++ b/frontend/app/(protected)/setup/congrats.tsx
@@ -28,7 +28,7 @@ export default function CompleteScreen() {
 
         <TouchableOpacity
           className="bg-[#0F172A] inline-flex min-w-[80px] py-4 px-8 justify-center items-center gap-1 rounded-full"
-          onPress={() => router.push('../dashboard/mydashboard/dashboard')}
+          onPress={() => router.push('../dashboard/family/family')}
         >
           <Text className="text-white text-center font-lato text-[16px] font-extrabold leading-[24px] tracking-[0.3px]">Next</Text>
         </TouchableOpacity>

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -27,8 +27,8 @@ export default function WelcomeScreen() {
 
           // Step 3: Redirect based on groupID status
           if (groupID) {
-            // User has a group, redirect to dashboard
-            router.push('/(protected)/dashboard/mydashboard/dashboard');
+            // User has a group, redirect to family
+            router.push('/(protected)/dashboard/family/family');
           } else {
             // User has no group, redirect to setup
             router.push('/(protected)/setup/health-input');

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -5,7 +5,7 @@ import Welcome from '../assets/images/welcome.png';
 import { useEffect } from 'react';
 
 export default function WelcomeScreen() {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, userId } = useAuth();
   const router = useRouter();
 
   useEffect(() => {

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -2,20 +2,59 @@ import { View, Text, TouchableOpacity, Image, SafeAreaView } from 'react-native'
 import { Link, useRouter } from 'expo-router';
 import { useAuth } from '@clerk/clerk-expo';
 import Welcome from '../assets/images/welcome.png';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 
 export default function WelcomeScreen() {
   const { isSignedIn, userId } = useAuth();
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (isSignedIn) {
-      router.push('/(protected)/dashboard/mydashboard/dashboard'); // Redirect to the home page if signed in
-    }
-  }, [isSignedIn, router]);
+        const checkUserGroup = async () => {
+      if (isSignedIn && userId) {
+        setIsLoading(true);
+        try {
+          // Step 1: Fetch userID using clerkID
+          const userResponse = await axios.get(`https://carebear-backend.onrender.com/api/users/clerk/${userId}`);
+          const userID = userResponse.data.userID;
+          console.log('Fetched userID for clerkID:', userID);
 
-  if (isSignedIn) {
-    return null; // Prevent rendering the rest of the component while redirecting
+          // Step 2: Get the user's groupID
+          const groupResponse = await axios.get(`https://carebear-backend.onrender.com/api/users/${userID}/group`);
+          const { groupID } = groupResponse.data;
+          console.log('User groupID status:', groupID ? 'Has group' : 'No group');
+
+          // Step 3: Redirect based on groupID status
+          if (groupID) {
+            // User has a group, redirect to dashboard
+            router.push('/(protected)/dashboard/mydashboard/dashboard');
+          } else {
+            // User has no group, redirect to setup
+            router.push('/(protected)/setup/health-input');
+          }
+        } catch (error) {
+          console.error('Error checking user group:', error);
+          // If there's an error, default to setup
+          router.push('/(protected)/setup/health-input');
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    checkUserGroup();
+  }, [isSignedIn, userId, router]);
+
+  // Show loading state while checking user status
+  if (isLoading || isSignedIn) {
+    return (
+      <SafeAreaView>
+        <View className="items-center justify-center h-screen bg-white">
+          <Text className="text-black font-lato text-lg">Loading...</Text>
+        </View>
+      </SafeAreaView>
+    );
   }
 
   return (


### PR DESCRIPTION
### Description

This pull request addresses the issue where users who sign in via social providers (Google, Facebook, Apple) are incorrectly directed to the dashboard even if they haven’t completed the onboarding process.

 **What’s Changed**

- After successful social authentication, the app now checks if the user is part of a family group.
- If the user has a family group: they are redirected to the dashboard as expected.
- If the user does not have a family group: they are redirected to the onboarding/setup flow.
- Users can only access the dashboard after completing the onboarding process.
- A short video demo is attached to showcase the updated authentication and redirection flow.

### Video Demo

https://github.com/user-attachments/assets/d825bd01-4859-414b-9072-dff831d86f69

